### PR TITLE
Fix curl not being available yet still being added in ``./configure``.

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -56,6 +56,9 @@ fn main() {
         if curl {
             cmd.arg("--with-libcurl");
         }
+        else if !curl {
+            cmd.arg("--without-libcurl");
+        }
         if gd {
             cmd.arg("--with-gd");
         }


### PR DESCRIPTION
Prevent linker errors such as this one:

```/usr/bin/ld: deps/libsixel_sys_static-629968730a463960.rlib(libsixel_la-status.o): in function `sixel_helper_format_error':
          status.c:(.text+0x31c): undefined reference to `curl_easy_strerror'
          collect2: error: ld returned 1 exit status```

In libsixel's documentation, you'll notice the default is ``auto`` - even if we don't pass the ``--with-libcurl`` flag, it may still build with curl.